### PR TITLE
Define overlap_br and overlap_req

### DIFF
--- a/spade_script/__init__.py
+++ b/spade_script/__init__.py
@@ -30,6 +30,8 @@ def validate_modulemd(modulemd_file, module_name):
     dependencies = mmd['data']['dependencies']
     module_br = set()
     module_req = set()
+    overlap_br = None
+    overlap_req = None
     for dependency in dependencies:
         if 'buildrequires' in dependency.keys():
             module_br = module_br.union(set(dependency['buildrequires']))


### PR DESCRIPTION
While validating modulemd, if a module contains no dependencies at all,
the variables overlap_br and overlap_req are never defined. This change
ensure they are always defined.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>