### PR TITLE
Assign upgraded object to local mmd var

### DIFF
--- a/spade_script/__init__.py
+++ b/spade_script/__init__.py
@@ -22,7 +22,7 @@ def validate_modulemd(modulemd_file, module_name):
     modulemd = json.dumps(modulemd)
     try:
         mmd = Modulemd.ModuleStream.read_string(modulemd, True)
-        mmd.upgrade(Modulemd.ModuleStreamVersionEnum.TWO)
+        mmd = mmd.upgrade(Modulemd.ModuleStreamVersionEnum.TWO)
     except Exception:
         raise ValueError('Invalid modulemd')
     dependencies = mmd.get_dependencies()


### PR DESCRIPTION
For some reason, mmd.upgrade() doesn't actually upgrade the local object in some cases. We recently encountered a few failures due to that. This change fixes it.